### PR TITLE
Add simple ping endpoint

### DIFF
--- a/backend/app/Http/Controllers/GameController.php
+++ b/backend/app/Http/Controllers/GameController.php
@@ -1,0 +1,16 @@
+<?php
+
+namespace App\Http\Controllers;
+
+use Illuminate\Http\JsonResponse;
+
+class GameController extends Controller
+{
+    /**
+     * Simple ping endpoint.
+     */
+    public function ping(): JsonResponse
+    {
+        return response()->json(['ping' => 'pong']);
+    }
+}

--- a/backend/routes/web.php
+++ b/backend/routes/web.php
@@ -1,7 +1,10 @@
 <?php
 
 use Illuminate\Support\Facades\Route;
+use App\Http\Controllers\GameController;
 
 Route::get('/', function () {
     return view('welcome');
 });
+
+Route::get('/api/ping', [GameController::class, 'ping']);

--- a/backend/tests/Feature/PingTest.php
+++ b/backend/tests/Feature/PingTest.php
@@ -1,0 +1,16 @@
+<?php
+
+namespace Tests\Feature;
+
+use Tests\TestCase;
+
+class PingTest extends TestCase
+{
+    /** @test */
+    public function ping_endpoint_returns_successful_response(): void
+    {
+        $this->get('/api/ping')
+            ->assertOk()
+            ->assertJson(['ping' => 'pong']);
+    }
+}


### PR DESCRIPTION
## Summary
- add `GameController` with ping method
- register `/api/ping` route
- test ping endpoint

## Testing
- `php artisan test` *(fails: php not found)*

------
https://chatgpt.com/codex/tasks/task_e_6859a0d697288323989f1e7545c9bc6d